### PR TITLE
Add SOQLConnection::isSalesForceId() to avoid some SalesForce IDs parsing as dates

### DIFF
--- a/src/Database/SOQLConnection.php
+++ b/src/Database/SOQLConnection.php
@@ -57,7 +57,8 @@ class SOQLConnection extends Connection
 		$query = str_replace('`', '', $query);
 		$bindings = array_map(function($item) {
 			try {
-				if (Carbon::parse($item) !== false) {
+				if (Carbon::parse($item) !== false &&
+                    !$this->isSalesForceId($item)) {
 					return $item;
 			    }
 		    } catch (\Exception $e) {
@@ -69,4 +70,17 @@ class SOQLConnection extends Connection
 		$query = str_replace_array('?', $bindings, $query);
 		return $query;
 	}
+
+    /**
+     * Based on characters and length of $str, determine if it appears to be a
+     * SalesForce ID.
+     *
+     * @param string $str String to test
+     *
+     * @return bool
+     */
+    private function isSalesForceId($str)
+    {
+        return \preg_match('/^[0-9a-zA-Z]{18}$/', $str);
+    }
 }


### PR DESCRIPTION
SOQLConnection::prepare() uses Carbon::parse() to test if a string is a date. Sometimes SalesForce IDs can parse as dates (i.e. Carbon parses 0031N0000288GeTQAU as a date).  When that occurs, the ID is not properly quoted.  I've added a isSalesForceId() method which attempts to determine if the paramater value matches the SalesForce ID format in order to avoid the issue.