### PR TITLE
Fix for SOQL breakage when there are no values for a WHERE IN() statement

### DIFF
--- a/src/Database/SOQLGrammar.php
+++ b/src/Database/SOQLGrammar.php
@@ -65,6 +65,21 @@ class SOQLGrammar extends Grammar
 		return parent::whereBasic($query, $where);
 	}
 
+    /**
+     * {@inheritDoc}
+     */
+    protected function whereIn(Builder $query, $where)
+    {
+        if (empty($where['values'])) {
+			// the below statement is invalid in SOQL
+			// return '0 = 1';
+			// since virtually every object in SalesForce has Id column then
+			// compare that field to null which should always be false.
+            return 'Id = null';
+        }
+		return parent::whereIn($query, $where);
+    }
+
 	/**
 	 * Compile the "join" portions of the query.
 	 *

--- a/src/Database/SOQLGrammar.php
+++ b/src/Database/SOQLGrammar.php
@@ -71,13 +71,13 @@ class SOQLGrammar extends Grammar
     protected function whereIn(Builder $query, $where)
     {
         if (empty($where['values'])) {
-			// the below statement is invalid in SOQL
-			// return '0 = 1';
-			// since virtually every object in SalesForce has Id column then
-			// compare that field to null which should always be false.
+            // the below statement is invalid in SOQL
+            // return '0 = 1';
+            // since virtually every object in SalesForce has Id column then
+            // compare that field to null which should always be false.
             return 'Id = null';
         }
-		return parent::whereIn($query, $where);
+        return parent::whereIn($query, $where);
     }
 
 	/**


### PR DESCRIPTION
In SOQLGrammar.php, override whereIn() to return Id = null instead of 0 = 1 when a where IN() is empty as 0 = 1 is not valid in SOQL.