### PR TITLE
Wrap find() call within Model::save() in a try...catch

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -82,7 +82,14 @@ abstract class Model extends EloquentModel
 				'body' => $body
 			]);
 
-			return isset($result['success']) ? $this->find($result['id']) : $this;
+            if (isset($result['success'])) {
+                try {
+                    return $this->find($result['id']);
+                } catch (\Exception $e) {
+                    ;
+                }
+            }
+            return $this;
 		} catch (\Exception $e) {
 			throw $e;
 		}

--- a/src/Model.php
+++ b/src/Model.php
@@ -82,14 +82,14 @@ abstract class Model extends EloquentModel
 				'body' => $body
 			]);
 
-            if (isset($result['success'])) {
-                try {
-                    return $this->find($result['id']);
-                } catch (\Exception $e) {
-                    ;
-                }
-            }
-            return $this;
+			if (isset($result['success'])) {
+				try {
+					return $this->find($result['id']);
+				} catch (\Exception $e) {
+					;
+				}
+			}
+			return $this;
 		} catch (\Exception $e) {
 			throw $e;
 		}

--- a/src/Model.php
+++ b/src/Model.php
@@ -86,7 +86,9 @@ abstract class Model extends EloquentModel
 				try {
 					return $this->find($result['id']);
 				} catch (\Exception $e) {
-					;
+					if (isset($result['id'])) {
+						$this->Id = $result['id'];
+					}
 				}
 			}
 			return $this;


### PR DESCRIPTION
The find() call within save() can sometimes fail and the caller has no good way of determining if the save() failed or if the subsequent internal find() did.  I ran into a find() failure when creating FeedItem object.  SF API will not allow the direct query of a FeedItem, but it does allow the creation.  So the subsequent find() call after a FeedItem creation would result in an Exception.

This fix just wraps the find() call within a try...catch to mask a failure from the save() caller.  Another option would be to create a new Exception type so the caller can differentiate between save()-fail and the internal find()-failure.