### PR TITLE
Support WHERE clauses in paginate() ; added support for cursor() and behavior change to select() in SOQLConnection

### DIFF
--- a/src/Database/SOQLBuilder.php
+++ b/src/Database/SOQLBuilder.php
@@ -10,131 +10,139 @@ use Lester\EloquentSalesForce\Facades\SObjects;
 
 class SOQLBuilder extends Builder
 {
+    /**
+     * {@inheritDoc}
+     */
+    public function __construct(QueryBuilder $query)
+    {
+        $query->connection = new SOQLConnection(null);
+        $query->grammar = new SOQLGrammar();
 
+        parent::__construct($query);
+    }
 
-	/**
-	 * Create a new Eloquent query builder instance.
-	 *
-	 * @param  \Illuminate\Database\Query\Builder  $query
-	 * @return void
-	 */
-	public function __construct(QueryBuilder $query)
-	{
-		$query->connection = new SOQLConnection(null);
-		$query->grammar = new SOQLGrammar();
+    /**
+     * {@inheritDoc}
+     */
+    public function getModels($columns = ['*'])
+    {
+        if (count($this->model->columns) &&
+            in_array('*', /** @scrutinizer ignore-type */ $columns)) {
+            $cols = $this->model->columns;
+        } else {
+            $cols = $this->getSalesForceColumns($columns);
+        }
+        return parent::getModels($cols);
+    }
 
-		parent::__construct($query);
-	}
+    /**
+     * {@inheritDoc}
+     */
+    public function cursor()
+    {
+        if (!$this->query->columns || in_array('*', $this->query->columns)) {
+            $this->query->columns = $this->model->columns;
+        }
 
-	/**
-	 * getModels function.
-	 *
-	 * @access public
-	 * @param string $columns (default: ['*'])
-	 * @return Array
-	 */
-	public function getModels($columns = ['*'])
- 	{
- 		return parent::getModels(count($this->model->columns) && in_array('*', /** @scrutinizer ignore-type */ $columns) ? $this->model->columns : $this->getSalesForceColumns($columns));
- 	}
+        return parent::cursor();
+    }
 
-	/**
-	 * Paginate the given query.
-	 *
-	 * @param  int  $perPage
-	 * @param  array  $columns
-	 * @param  string  $pageName
-	 * @param  int|null  $page
-	 * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
-	 *
-	 * @throws \InvalidArgumentException
-	 */
-	public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
-	{
-		$columns = $this->getSalesForceColumns($columns);
+    /**
+     * {@inheritDoc}
+     */
+    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
+    {
+        $columns = $this->getSalesForceColumns($columns);
 
-		$table = $this->model->getTable();
+        $table = $this->model->getTable();
 
-		/** @scrutinizer ignore-call */
-		$total = SObjects::query("SELECT COUNT() FROM $table")['totalSize'];
+        /** @scrutinizer ignore-call */
+        //$total = SObjects::query("SELECT COUNT() FROM $table")['totalSize'];
+        $builder = $this->getQuery()->cloneWithout(
+            ['columns', 'orders', 'limit', 'offset']
+        );
+        $builder->aggregate = ['function' => 'count', 'columns' => ['Id']];
+        $total = $builder->get()[0]['aggregate'];
+        if ($total > 2000) { // SOQL OFFSET limit is 2000
+            $total = 2000;
+        }
 
-		$page = $page ?: Paginator::resolveCurrentPage($pageName);
-		$perPage = $perPage ?: $this->model->getPerPage();
-		$results = $total
-									? /** @scrutinizer ignore-call */ $this->forPage($page, $perPage)->get($columns)
-									: $this->model->newCollection();
-		return $this->paginator($results, $total, $perPage, $page, [
-			'path' => Paginator::resolveCurrentPath(),
-			'pageName' => $pageName,
-		]);
-	}
+        $page = $page ?: Paginator::resolveCurrentPage($pageName);
+        $perPage = $perPage ?: $this->model->getPerPage();
+        $results = $total
+            ? /** @scrutinizer ignore-call */ $this->forPage($page, $perPage)->get($columns)
+            : $this->model->newCollection();
+        return $this->paginator($results, $total, $perPage, $page, [
+            'path' => Paginator::resolveCurrentPath(),
+            'pageName' => $pageName,
+        ]);
+    }
 
-	/**
-	 * Mass insert of models
-	 * @return Illuminate\Support\Collection of models.
-	 */
-	public function insert(\Illuminate\Support\Collection $collection)
-	{
-		$table = $this->model->getTable();
+    /**
+     * {@inheritDoc}
+     */
+    public function insert(\Illuminate\Support\Collection $collection)
+    {
+        $table = $this->model->getTable();
 
-		$counter = 1;
-		$collection = $collection->map(function($object, $index) {
-			$attrs = $object->sf_attributes;
-			$attrs['referenceId'] = 'ref' . $index;
-			$object->sf_attributes = $attrs;
-			return $object;
-		});
+        $counter = 1;
+        $collection = $collection->map(function($object, $index) {
+            $attrs = $object->sf_attributes;
+            $attrs['referenceId'] = 'ref' . $index;
+            $object->sf_attributes = $attrs;
+            return $object;
+        });
 
-		$payload = [
+        $payload = [
             'method' => 'post',
             'body' => [
                 'records' => $collection->toArray()
             ]
         ];
 
-		/** @scrutinizer ignore-call */
-		$response = SObjects::composite('tree/' . $table, $payload);
+        /** @scrutinizer ignore-call */
+        $response = SObjects::composite('tree/' . $table, $payload);
 
-		$response = collect($response['results']);
-		$model = $this->model;
-		$response = $response->map(function($item) use ($model) {
-			unset($item['referenceId']);
-			foreach ($item as $key => $value) {
-				$item[ucwords($key)] = $value;
-				unset($item[$key]);
-			}
-			return new $model($item);
-		});
+        $response = collect($response['results']);
+        $model = $this->model;
+        $response = $response->map(function($item) use ($model) {
+            unset($item['referenceId']);
+            foreach ($item as $key => $value) {
+                $item[ucwords($key)] = $value;
+                unset($item[$key]);
+            }
+            return new $model($item);
+        });
 
-		return $response;
-	}
+        return $response;
+    }
 
-	/**
-	 * getSalesForceColumns function.
-	 *
-	 * @access protected
-	 * @param mixed $columns
-	 * @param mixed $table (default: null)
-	 * @return array
-	 */
-	protected function getSalesForceColumns($columns, $table = null) {
-		$table = $table ?: $this->model->getTable();
+    /**
+     * getSalesForceColumns function.
+     *
+     * @access protected
+     * @param mixed $columns
+     * @param mixed $table (default: null)
+     * @return array
+     */
+    protected function getSalesForceColumns($columns, $table = null)
+    {
+        $table = $table ?: $this->model->getTable();
 
-		return ServiceProvider::objectFields($table, $columns);
-	}
+        return ServiceProvider::objectFields($table, $columns);
+    }
 
-	/**
-	 * describe function. returns columns of object.
-	 *
-	 * @return array
-	 */
-	public function describe()
- 	{
- 		$table = $this->model->getTable();
+    /**
+     * describe function. returns columns of object.
+     *
+     * @return array
+     */
+    public function describe()
+    {
+        $table = $this->model->getTable();
 
- 		if (count($this->model->columns)) return $this->model->columns;
+        if (count($this->model->columns)) return $this->model->columns;
 
- 		return $this->getSalesForceColumns(['*'], $table);
- 	}
-
+        return $this->getSalesForceColumns(['*'], $table);
+    }
 }


### PR DESCRIPTION
Updated paginate() to use the original query to obtain a COUNT(), but limit total to 2000 because that is all SOQL's OFFSET supports.  Prior to this change, paginate() was useless if your query had a WHERE clause.

Updated select() in SOQLConnection to return *all* results from SalesForce (by continually calling next()) rather than just up to 2000. Using the method can certaily lead to long load times and high memory usage, however I beleive it's the responsiblity of the caller to use LIMIT or cursor() (which has been implemented in this commit as well) in order to reduce memory usage.   select() is defined by Eloquent to return *all* results so I believe that should be the behavior of this SOQL driver as well.

Implmented the cursor() method to support yield-ing over a result set.  It's important to note that with a typical RDBM driver for Eloquent, cursor() would allow you to store one row in memory at any given time.  However due to the nature of SOQL and it being a remote API with quota restrictions, it's unreasonable to make API calls row-by-row.  So cursor() that has been implemented will still store up to the SOQL-max of 2000 records at once, however it will yeild them one by one and call next() transparently in the background for the Eloquent user.