### PR TITLE
Update composer.json For Laravel 6.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,10 @@
     }
   ],
   "require": {
-    "php": ">=7.0",
+    "php": ">=7.2",
     "laravel/framework": ">=5.5",
-    "omniphx/forrest": "2.*"
+    "omniphx/forrest": "2.*",
+    "laravel/helpers": "^1.1"
   },
   "require-dev": {
     "orchestra/testbench": "~3.6.0",


### PR DESCRIPTION
Updated Composer JSON for compatibility with Laravel 6.

All str_ and array_ helpers have been moved to the new laravel/helpers Composer package and removed from the framework.