### PR TITLE
Use splat operator to laravel 7.0 support

### DIFF
--- a/src/Database/SOQLBatch.php
+++ b/src/Database/SOQLBatch.php
@@ -46,7 +46,7 @@ class SOQLBatch extends Collection
         ];
     }
 
-    public function push($builder)
+    public function push(...$builder)
     {
         return tap($this, function($collection) use ($builder) {
             $collection->batch($builder);


### PR DESCRIPTION
**Laravel 7. x**

**Issue Details**
Exception: `Declaration of Lester\EloquentSalesForce\Database\SOQLBatch::push($builder) should be compatible with Illuminate\Support\Collection::push(...$values)`

File: SOQLBatch.php
Line: 49
Function: push($builder)

**Issues Addressed**
Used splat operator in push method argument to capture a number of arguments to a function.