### PR TITLE
Update SOQLConnection.php

### DIFF
--- a/src/Database/SOQLConnection.php
+++ b/src/Database/SOQLConnection.php
@@ -102,11 +102,13 @@ class SOQLConnection extends Connection
 		$query = str_replace('`', '', $query);
 		$bindings = array_map(function($item) {
 			try {
-				if (\Carbon\Carbon::parse($item) !== false && !$this->isSalesForceId($item)) {
+				if (strlen($item) > 9 && \Carbon\Carbon::parse($item) !== false && !$this->isSalesForceId($item)) {
 					return $item;
 				}
 			} catch (\Exception $e) {
-				if (is_int($item) || is_float($item)) {
+				if (is_string($item)){
+                    return "'$item'";
+                } else if (is_int($item) || is_float($item)) {
 					return $item;
 				} else {
 					return "'$item'";


### PR DESCRIPTION
We have an auto number field with no prefix (example: 1216560), which is being identified as an int or a Carbon time string but needs to be returned as a string with quotes. As most Carbon parse strings are usually 10 or more characters, we check for a minimum character length.