### PR TITLE
Update SOQLHasOneOrMany.php

### DIFF
--- a/src/Database/SOQLHasOneOrMany.php
+++ b/src/Database/SOQLHasOneOrMany.php
@@ -367,7 +367,7 @@ abstract class SOQLHasOneOrMany extends Relation
 	 *
 	 * @return string
 	 */
-	public function getRelationCountHash()
+	public function getRelationCountHash($incrementJoinCount = true)
 	{
 		return 'laravel_reserved_' . static::$selfJoinCount++;
 	}


### PR DESCRIPTION
Fixes error where getRelationCountHash is not compatible with the extended relation.php file from Illminate/Eloquent/Relations/Relation.php