### PR TITLE
Update SOQLHasOneOrMany.php

### DIFF
--- a/src/Database/SOQLHasOneOrMany.php
+++ b/src/Database/SOQLHasOneOrMany.php
@@ -367,7 +367,7 @@ abstract class SOQLHasOneOrMany extends Relation
 	 *
 	 * @return string
 	 */
-	public function getRelationCountHash()
+	public function getRelationCountHash($incrementJoinCount = true)
 	{
 		return 'laravel_reserved_' . static::$selfJoinCount++;
 	}


### PR DESCRIPTION
Fixes the following error on Laravel 8: "ExceptionError: Declaration of Lester\EloquentSalesForce\Database\SOQLHasOneOrMany::getRelationCountHash()"