### PR TITLE
fix to allow cursor method to work with the trashed methods

### DIFF
--- a/src/Database/SOQLConnection.php
+++ b/src/Database/SOQLConnection.php
@@ -82,6 +82,11 @@ class SOQLConnection extends Connection
 
 			$statement = $this->prepare($query, $bindings);
 
+            if ( $this->all ) {
+                /** @scrutinizer ignore-call */
+                return SObjects::queryAll($statement);
+            }
+
 			/** @scrutinizer ignore-call */
 			return SObjects::query($statement);
 		});


### PR DESCRIPTION
Addresses and fixes this issue: https://github.com/roblesterjr04/EloquentSalesForce/issues/79