### PR TITLE
(fix): correct facade

### DIFF
--- a/src/Database/SOQLGrammar.php
+++ b/src/Database/SOQLGrammar.php
@@ -2,14 +2,14 @@
 
 namespace Lester\EloquentSalesForce\Database;
 
+use Carbon\Carbon;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Query\Grammars\Grammar;
+use Illuminate\Database\Query\JsonExpression;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Illuminate\Database\Query\Builder;
-use Illuminate\Database\Query\JsonExpression;
-use Illuminate\Database\Query\Grammars\Grammar;
+use Lester\EloquentSalesForce\Facades\SObjects;
 use Lester\EloquentSalesForce\ServiceProvider;
-use SObjects;
-use Carbon\Carbon;
 
 class SOQLGrammar extends Grammar
 {


### PR DESCRIPTION
I got class 'SObjects' not found, when calling `Contact::where('Email', 'test@test.com')->first();`.

Fixed the error using the correct facade path.

![screenshot-ddma-portal lndo site-2021 12 23-10_20_34](https://user-images.githubusercontent.com/4084596/147218945-d8211120-2f5f-49d2-8480-43db6254d144.png)
