### PR TITLE
Fire deleted event from the Salesforce model.

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -100,12 +100,18 @@ abstract class Model extends EloquentModel
 
 	public function delete()
 	{
+
+        if ($this->fireModelEvent('deleting') === false) {
+            return false;
+        }
+
 		try {
 			/** @scrutinizer ignore-call */
 			SObjects::sobjects($this->table . '/' . $this->Id, [
 				'method' => 'delete'
 			]);
 			SObjects::log("{$this->table} object {$this->Id} deleted.");
+            $this->fireModelEvent('deleted', false);
 			return true;
 		} catch (\Exception $e) {
 			SObjects::log("{$this->table} object {$this->Id} failed to delete.", (array)$e, 'warning');


### PR DESCRIPTION
This pull request updates the base Model class so the delete() method fires the corresponding _deleted_ event that can be observed in the standard Laravel fashion. It follows the same pattern already used for the _updated_ and _created_ events in the same class.