### PR TITLE
[2.x] Escape single-quotes from SOQLConnection

### DIFF
--- a/src/Database/SOQLConnection.php
+++ b/src/Database/SOQLConnection.php
@@ -156,7 +156,7 @@ class SOQLConnection extends Connection
             } else if (is_bool($value)) {
                 $bindings[$key] = $value ? 'TRUE' : 'FALSE';
             } else if (is_string($value) {
-            	$bindings[$key] = Str::of($value)->replace("'", "\'");
+            	$bindings[$key] = Str::replace("'", "\'", $value);
             }
         }
 

--- a/src/Database/SOQLConnection.php
+++ b/src/Database/SOQLConnection.php
@@ -155,6 +155,8 @@ class SOQLConnection extends Connection
                 $bindings[$key] = $value->format($grammar->getDateFormat());
             } else if (is_bool($value)) {
                 $bindings[$key] = $value ? 'TRUE' : 'FALSE';
+            } else if (is_string($value) {
+            	$bindings[$key] = Str::of($value)->replace("'", "\'");
             }
         }
 

--- a/src/Database/SOQLConnection.php
+++ b/src/Database/SOQLConnection.php
@@ -155,7 +155,7 @@ class SOQLConnection extends Connection
                 $bindings[$key] = $value->format($grammar->getDateFormat());
             } else if (is_bool($value)) {
                 $bindings[$key] = $value ? 'TRUE' : 'FALSE';
-            } else if (is_string($value) {
+            } else if (is_string($value)) {
             	$bindings[$key] = Str::replace("'", "\'", $value);
             }
         }

--- a/tests/EloquentSalesForceTest.php
+++ b/tests/EloquentSalesForceTest.php
@@ -35,6 +35,21 @@ class EloquentSalesForceTest extends TestCase
 
     private $lead;
 
+    public function testStringEscapesSingleQuotes()
+    {
+        $lead = TestLead::create([
+            'FirstName' => 'Sinead',
+            'LastName' => "O'Connor",
+            'Company' => 'Test',
+            'Email' => 'test@test.com',
+            'Custom_Text_Field__c' => '009',
+        ]);
+
+        $freshLead = $lead->where('LastName', "O'Connor")->latest()->first();
+
+        $this->assertEquals($lead->Id, $freshLead->Id);
+    }
+
     public function testStringType()
     {
         $lead = TestLead::create([


### PR DESCRIPTION
@roblesterjr04 revisiting **[this bit from #95](https://github.com/roblesterjr04/EloquentSalesForce/issues/95#issuecomment-1632883706)** tonight, and I'm pretty sure #96 doesn't actually solve the underlying problem. 

I've continued to get SOQL errors related to unescaped quotes. As far as I can tell, the `toSql` method inside of `SOQLBuilder.php` never actually gets called, at least not on `SELECT` queries. Eg, you can chuck a `dd('won't ever show');` into the top of that method, hit a page or endpoint that calls a select query, and it will go through without dumping. This _might_ be anecdotal, but at least on simple tests I ran, it's never getting called.

I think what's happening with that `SOQLBuilder` class, is that it's intending to override the `toSql` method from its parent...but `SOQLBuilder` extends the _**Eloquent**_ Builder, not the _**Query**_ Builder, and that `toSql` method exists on the latter. It therefore never gets called on the former, which means the `SOQLBuilder`'s override never gets called either. This is handled via the `$passthru` property from the Eloquent Builder, which (via the `toBase()` method) hands off calls like `toSql` down to the _Query_ Builder.

Definitely wouldn't put money on this, but I suspect you could delete that entire `toSql` method from `SOQLBuilder`, and nothing would break, as I just don't think it gets called anywhere (except _maybe_ in `SOQLBatch`). 

Will defer to you on any changes to that class, though—this PR doesn't touch it.

---

**So TL;DR -** this PR essentially takes the patch in #96, and relocates it to the `SOQLConnection->prepareBindings()` method with an `is_string` check, where it actually gets called & applied.

**I would definitely give this all a thorough review, though, as I think there might be some security considerations with how `'` and similar characters are able to be passed in? Dunno, that's not my forte, so I defer to your expertise.** 🙂 That said, let me know if there's anything you'd like to see modified with this PR; happy to help where I can.