### PR TITLE
Use normal Eloquent hydratation in batch

### DIFF
--- a/src/Database/SOQLBatch.php
+++ b/src/Database/SOQLBatch.php
@@ -106,10 +106,7 @@ class SOQLBatch extends Collection
                 if ($batch_result['statusCode'] != 200) {
                     $batch->results = (object)$batch_result;
                 } else {
-                    $batch->results = collect($batch_result['result']['records'])->map(function($item) use ($batch) {
-                        $model = $batch->class;
-                        return new $model($item);
-                    });
+                    $batch->results = $batch->builder->hydrate($batch_result['result']['records']);
                 }
                 $this->put($key, $batch);
                 $index++;


### PR DESCRIPTION
Hello,

First thank you for this great library that helped us a lot.

We hit an issues when using the batch query method, the resulting models had the `original` attribute set to an empty array, which cause any save after that to result in this `SalesforceException`:

```
[ { "message": "The Id field should not be specified in the sobject data.", "errorCode": "INVALID_FIELD" } ]
```

I adapted the code to use the normal Eloquent hydration method, so that all the attribute are set as usual after a query.