### PR TITLE
Update SObjects.php so getPicklistValues() is static

### DIFF
--- a/src/SObjects.php
+++ b/src/SObjects.php
@@ -175,7 +175,7 @@ class SObjects
 	 * @param  [type] $field  [description]
 	 * @return [type]         [description]
 	 */
-	public function getPicklistValues($object, $field)
+	public static function getPicklistValues($object, $field)
 	{
 		Forrest::authenticate();
 		$desc = Forrest::sobjects($object . '/describe');


### PR DESCRIPTION
This way the method described in the doccumentation works on the new versions too without throwing an error.

`$statusValue = SObjects::getPicklistValues('Lead', 'Status');`

This documented method in the documentation https://roblesterjr04.github.io/EloquentSalesForce/index.html#/?id=picklists throws and error on newer versions of php (8.2 in my case)