### PR TITLE
add `Id` to TestTask

### DIFF
--- a/src/TestTask.php
+++ b/src/TestTask.php
@@ -7,6 +7,7 @@ class TestTask extends Model
 	protected $table = 'Task';
 
     public $columns = [
+    	'Id',
         'WhoId',
         'Subject',
     ];


### PR DESCRIPTION
In `SOQLBuilder`, the `delete` method (by way of `truncate`) expects the `Id` of each record to be present, so that it can pluck and implode it. That field was missing from `TestTask` and it seemed to break _all_ tests, due to the truncation methods called in `setUp`.